### PR TITLE
Use the same behaviour than Ruby 2.3 shellescape

### DIFF
--- a/lib/extras/shell.rb
+++ b/lib/extras/shell.rb
@@ -39,6 +39,7 @@ module Extras
         end
 
       else
+        str = str.to_s
         regexp = /((?:\\)?[^A-Za-z0-9_\-.,:\/@\n])/
         str = str.gsub(regexp) { $1.start_with?("\\") ? $1 : "\\#{$1}" }
         str = str.gsub(/\n/, "'\n'")

--- a/spec/tests/lib/extras/shell_spec.rb
+++ b/spec/tests/lib/extras/shell_spec.rb
@@ -58,5 +58,14 @@ describe Shellwords do
         described_class.escape("&")
       )
     end
+
+    #
+
+    it "should escape pathnames" do
+      expect(described_class.escape(described_class.escape(Pathname.new("")))).to eq(
+        described_class.escape("''")
+      )
+    end
+
   end
 end


### PR DESCRIPTION
In it's current state the `escape` method doesn't accept `Pathname` instances:

```ruby
> Shellwords.escape(Pathname.new(""))
NoMethodError:
       undefined method `gsub' for #<Pathname:>
```

As this gem rewrites the behaviour of the original method this can create surprising behavior:

```ruby
> [Pathname.new("foo"), "bar"].shelljoin
NoMethodError:
       undefined method `gsub' for #<Pathname:>
```

This PR fixes this problem by following more closely the [original implementation](https://github.com/ruby/ruby/blob/ruby_2_3/lib/shellwords.rb#L132) and thus supporting more than a mere string.